### PR TITLE
Add share extension icon configuration

### DIFF
--- a/bitchat-main/bitchatShareExtension/Info.plist
+++ b/bitchat-main/bitchatShareExtension/Info.plist
@@ -8,6 +8,16 @@
 	<string>bitchat</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIconName</key>
+	<string>AppIcon</string>
+	<key>CFBundleIcons</key>
+	<dict>
+		<key>CFBundlePrimaryIcon</key>
+		<dict>
+			<key>CFBundleIconName</key>
+			<string>AppIcon</string>
+		</dict>
+	</dict>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>


### PR DESCRIPTION
## Summary
- define AppIcon as the share extension's bundle icon
- declare primary icon mapping in share extension Info.plist

## Testing
- `xcodebuild test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897ae588b2c832e887d3ab2c287cf7a