### PR TITLE
Add PM consent persistence and peer fingerprint mapper

### DIFF
--- a/bitchat-main/bitchat/Identity/PeerFingerprintMapper.swift
+++ b/bitchat-main/bitchat/Identity/PeerFingerprintMapper.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Maintains bidirectional mappings between ephemeral peer IDs and stable fingerprints.
+/// Provides thread-safe access across the application.
+final class PeerFingerprintMapper {
+    static let shared = PeerFingerprintMapper()
+
+    private var peerIDToFingerprint: [String: String] = [:]
+    private var fingerprintToPeerID: [String: String] = [:]
+    private let queue = DispatchQueue(label: "chat.bitchat.peerFingerprintMapper", attributes: .concurrent)
+
+    private init() {}
+
+    /// Associates a peer ID with a fingerprint.
+    func setFingerprint(_ fingerprint: String, for peerID: String) {
+        queue.async(flags: .barrier) {
+            self.peerIDToFingerprint[peerID] = fingerprint
+            self.fingerprintToPeerID[fingerprint] = peerID
+        }
+    }
+
+    /// Retrieves the fingerprint for a peer ID.
+    func fingerprint(for peerID: String) -> String? {
+        queue.sync {
+            peerIDToFingerprint[peerID]
+        }
+    }
+
+    /// Retrieves the current peer ID for a fingerprint.
+    func peerID(for fingerprint: String) -> String? {
+        queue.sync {
+            fingerprintToPeerID[fingerprint]
+        }
+    }
+
+    /// Removes all mappings for a peer ID.
+    func removePeerID(_ peerID: String) {
+        queue.async(flags: .barrier) {
+            if let fingerprint = self.peerIDToFingerprint.removeValue(forKey: peerID) {
+                self.fingerprintToPeerID.removeValue(forKey: fingerprint)
+            }
+        }
+    }
+}
+

--- a/bitchat-main/bitchat/Identity/SecureIdentityStateManager.swift
+++ b/bitchat-main/bitchat/Identity/SecureIdentityStateManager.swift
@@ -351,10 +351,11 @@ class SecureIdentityStateManager {
     func updateHandshakeState(peerID: String, state: HandshakeState) {
         queue.async(flags: .barrier) {
             self.ephemeralSessions[peerID]?.handshakeState = state
-            
+
             // If handshake completed, update last interaction
             if case .completed(let fingerprint) = state {
                 self.cache.lastInteractions[fingerprint] = Date()
+                PeerFingerprintMapper.shared.setFingerprint(fingerprint, for: peerID)
                 self.saveIdentityCache()
             }
         }
@@ -428,6 +429,7 @@ class SecureIdentityStateManager {
         queue.async(flags: .barrier) {
             self.ephemeralSessions.removeValue(forKey: peerID)
             self.pendingActions.removeValue(forKey: peerID)
+            PeerFingerprintMapper.shared.removePeerID(peerID)
         }
     }
     

--- a/bitchat-main/bitchat/Services/PMConsentStore.swift
+++ b/bitchat-main/bitchat/Services/PMConsentStore.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Represents the consent status for private messages between two peers.
+enum PMConsentStatus: String {
+    case unknown
+    case requested
+    case accepted
+    case refused
+}
+
+/// Stores and retrieves private message consent statuses between peers.
+/// Uses fingerprints as identifiers and persists data in UserDefaults.
+final class PMConsentStore {
+    static let shared = PMConsentStore()
+
+    private let userDefaults: UserDefaults
+    private let storagePrefix = "chat.bitchat.pmconsent"
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
+    /// Retrieves the consent status between two fingerprints.
+    func status(between myFingerprint: String, and otherFingerprint: String) -> PMConsentStatus {
+        let key = storageKey(for: myFingerprint, and: otherFingerprint)
+        if let raw = userDefaults.string(forKey: key), let status = PMConsentStatus(rawValue: raw) {
+            return status
+        }
+        return .unknown
+    }
+
+    /// Sets the consent status between two fingerprints.
+    func setStatus(_ status: PMConsentStatus, between firstFingerprint: String, and secondFingerprint: String) {
+        let key = storageKey(for: firstFingerprint, and: secondFingerprint)
+        if status == .unknown {
+            userDefaults.removeObject(forKey: key)
+        } else {
+            userDefaults.set(status.rawValue, forKey: key)
+        }
+        userDefaults.synchronize()
+    }
+
+    /// Creates a deterministic key for two fingerprints.
+    private func storageKey(for fingerprintA: String, and fingerprintB: String) -> String {
+        let sorted = [fingerprintA, fingerprintB].sorted()
+        return "\(storagePrefix).\(sorted[0])|\(sorted[1])"
+    }
+}
+


### PR DESCRIPTION
## Summary
- Add `PMConsentStatus` and `PMConsentStore` for persistent PM consent using fingerprints
- Introduce thread-safe `PeerFingerprintMapper` service to map peer IDs to fingerprints
- Integrate mapper into `SecureIdentityStateManager` for automatic updates on handshake completion and session removal

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68986c627144832e9dc6c6f00228026b