### PR TITLE
feat(identity): add PeerFingerprintMapper with persisted mapping and thread-safety

### DIFF
--- a/bitchat-main/Echo.xcodeproj/project.pbxproj
+++ b/bitchat-main/Echo.xcodeproj/project.pbxproj
@@ -109,7 +109,11 @@
 		D948085736ED8E736C1DE3B0 /* BluetoothMeshService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5C3D880FF8AE1673B20E1E3 /* BluetoothMeshService.swift */; };
 		E65BBB6544FE0159F3C6C3A8 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 95F16C3A4A5621C74461D8D3 /* LaunchScreen.storyboard */; };
 		F455F011B3B648ADA233F998 /* BinaryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2136C3E22D02D4A8DBE7EAB /* BinaryProtocol.swift */; };
-		FB8819B4C84FAFEF5C36B216 /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136696FC4436A02D98CE6A77 /* KeychainManager.swift */; };
+                FB8819B4C84FAFEF5C36B216 /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136696FC4436A02D98CE6A77 /* KeychainManager.swift */; };
+                BCA92808B85847C6A1564FF5 /* PeerFingerprintMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E141D46234E4D2F85E7DD2E /* PeerFingerprintMapper.swift */; };
+                61DD14580F334EB9B346AC5D /* PeerFingerprintMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E141D46234E4D2F85E7DD2E /* PeerFingerprintMapper.swift */; };
+                DAA46FBB15014AF1A60AF7F5 /* PeerFingerprintMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DF54C798CA441A38B627A49 /* PeerFingerprintMapperTests.swift */; };
+                B7C18CECBE2D40D29E32CCBD /* PeerFingerprintMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DF54C798CA441A38B627A49 /* PeerFingerprintMapperTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -212,8 +216,10 @@
 		E6B8F7B7D55092C2540A7996 /* ChatViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModel.swift; sourceTree = "<group>"; };
 		EA706D8E5097785414646A8E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		ED176FF3B274E35C2D827894 /* BatteryOptimizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatteryOptimizer.swift; sourceTree = "<group>"; };
-		EF625BB3AD919322C01A46B2 /* BitchatApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitchatApp.swift; sourceTree = "<group>"; };
-		FF7AF93D874001FBD94C8306 /* bitchat-macOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "bitchat-macOS.entitlements"; sourceTree = "<group>"; };
+                EF625BB3AD919322C01A46B2 /* BitchatApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitchatApp.swift; sourceTree = "<group>"; };
+                FF7AF93D874001FBD94C8306 /* bitchat-macOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "bitchat-macOS.entitlements"; sourceTree = "<group>"; };
+                6E141D46234E4D2F85E7DD2E /* PeerFingerprintMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerFingerprintMapper.swift; sourceTree = "<group>"; };
+                0DF54C798CA441A38B627A49 /* PeerFingerprintMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerFingerprintMapperTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -443,36 +449,54 @@
 			path = Protocols;
 			sourceTree = "<group>";
 		};
-		C3D98EB3E1B455E321F519F4 /* bitchatTests */ = {
-			isa = PBXGroup;
-			children = (
-				04636BE22E30BEC600FBCFA8 /* Integration */,
-				04636BC62E30BE5100FBCFA8 /* EndToEnd */,
-				04636BC92E30BE5100FBCFA8 /* Mocks */,
-				04636BCB2E30BE5100FBCFA8 /* Noise */,
-				04636BCD2E30BE5100FBCFA8 /* Protocol */,
-				04636BD02E30BE5100FBCFA8 /* TestUtilities */,
-				D69A18D27F9A565FD6041E12 /* Info.plist */,
-			);
-			path = bitchatTests;
-			sourceTree = "<group>";
-		};
-		D98A3186D7E4C72E35BDF7FE /* Services */ = {
-			isa = PBXGroup;
-			children = (
-				04F127F62E37EEEE00FFBA8D /* FavoritesPersistenceService.swift */,
-				04F127F72E37EEEE00FFBA8D /* MessageRouter.swift */,
-				04F127FF2E37F00000FFBA8D /* ProcessedMessagesService.swift */,
-				04B6BA4D2E2038A70090FE39 /* NoiseEncryptionService.swift */,
-				D5C3D880FF8AE1673B20E1E3 /* BluetoothMeshService.swift */,
-				12B9C3EDF3BC73D3BC106DA4 /* DeliveryTracker.swift */,
-				136696FC4436A02D98CE6A77 /* KeychainManager.swift */,
-				AA4D7595A613F7ED3B386132 /* MessageRetryService.swift */,
-				3448F84BF86A42A3CC4A9379 /* NotificationService.swift */,
-			);
-			path = Services;
-			sourceTree = "<group>";
-		};
+                C3D98EB3E1B455E321F519F4 /* bitchatTests */ = {
+                        isa = PBXGroup;
+                        children = (
+                                04636BE22E30BEC600FBCFA8 /* Integration */,
+                                04636BC62E30BE5100FBCFA8 /* EndToEnd */,
+                                04636BC92E30BE5100FBCFA8 /* Mocks */,
+                                04636BCB2E30BE5100FBCFA8 /* Noise */,
+                                04636BCD2E30BE5100FBCFA8 /* Protocol */,
+                                04636BD02E30BE5100FBCFA8 /* TestUtilities */,
+                                D26DDDF7D0D0447193BF12D1 /* Identity */,
+                                D69A18D27F9A565FD6041E12 /* Info.plist */,
+                        );
+                        path = bitchatTests;
+                        sourceTree = "<group>";
+                };
+                D98A3186D7E4C72E35BDF7FE /* Services */ = {
+                        isa = PBXGroup;
+                        children = (
+                                04F127F62E37EEEE00FFBA8D /* FavoritesPersistenceService.swift */,
+                                04F127F72E37EEEE00FFBA8D /* MessageRouter.swift */,
+                                04F127FF2E37F00000FFBA8D /* ProcessedMessagesService.swift */,
+                                04B6BA4D2E2038A70090FE39 /* NoiseEncryptionService.swift */,
+                                D5C3D880FF8AE1673B20E1E3 /* BluetoothMeshService.swift */,
+                                12B9C3EDF3BC73D3BC106DA4 /* DeliveryTracker.swift */,
+                                136696FC4436A02D98CE6A77 /* KeychainManager.swift */,
+                                AA4D7595A613F7ED3B386132 /* MessageRetryService.swift */,
+                                3448F84BF86A42A3CC4A9379 /* NotificationService.swift */,
+                                9B55F974EB54461AA794BECD /* Identity */,
+                        );
+                        path = Services;
+                        sourceTree = "<group>";
+                };
+        9B55F974EB54461AA794BECD /* Identity */ = {
+                isa = PBXGroup;
+                children = (
+                        6E141D46234E4D2F85E7DD2E /* PeerFingerprintMapper.swift */,
+                );
+                path = Identity;
+                sourceTree = "<group>";
+        };
+        D26DDDF7D0D0447193BF12D1 /* Identity */ = {
+                isa = PBXGroup;
+                children = (
+                        0DF54C798CA441A38B627A49 /* PeerFingerprintMapperTests.swift */,
+                );
+                path = Identity;
+                sourceTree = "<group>";
+        };
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -701,11 +725,12 @@
 				04636BBF2E2FCA8A00FBCFA8 /* SecureLogger.swift in Sources */,
 				0245710AEAA58AD0A1425234 /* OptimizedBloomFilter.swift in Sources */,
 				04F127F82E37EEEE00FFBA8D /* MessageRouter.swift in Sources */,
-				04F127F92E37EEEE00FFBA8D /* FavoritesPersistenceService.swift in Sources */,
-				04F128042E37F00000FFBA8D /* ProcessedMessagesService.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+                                04F127F92E37EEEE00FFBA8D /* FavoritesPersistenceService.swift in Sources */,
+                                04F128042E37F00000FFBA8D /* ProcessedMessagesService.swift in Sources */,
+                                61DD14580F334EB9B346AC5D /* PeerFingerprintMapper.swift in Sources */,
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
 		4E49E34F00154C051AE90FED /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -748,11 +773,12 @@
 				04636BC02E2FCA8A00FBCFA8 /* SecureLogger.swift in Sources */,
 				1F48A8CEEE9399D1EBD08F0C /* OptimizedBloomFilter.swift in Sources */,
 				04F127FA2E37EEEE00FFBA8D /* MessageRouter.swift in Sources */,
-				04F127FB2E37EEEE00FFBA8D /* FavoritesPersistenceService.swift in Sources */,
-				04F128052E37F00000FFBA8D /* ProcessedMessagesService.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+                                04F127FB2E37EEEE00FFBA8D /* FavoritesPersistenceService.swift in Sources */,
+                                04F128052E37F00000FFBA8D /* ProcessedMessagesService.swift in Sources */,
+                                BCA92808B85847C6A1564FF5 /* PeerFingerprintMapper.swift in Sources */,
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
 		5C22AA7B9ACC5A861445C769 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -764,11 +790,12 @@
 				04636BDC2E30BE5100FBCFA8 /* TestConstants.swift in Sources */,
 				04636BDD2E30BE5100FBCFA8 /* MockBluetoothMeshService.swift in Sources */,
 				04636BDE2E30BE5100FBCFA8 /* NoiseProtocolTests.swift in Sources */,
-				04636BDF2E30BE5100FBCFA8 /* TestHelpers.swift in Sources */,
-				04636BE02E30BE5100FBCFA8 /* PublicChatE2ETests.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+                                04636BDF2E30BE5100FBCFA8 /* TestHelpers.swift in Sources */,
+                                04636BE02E30BE5100FBCFA8 /* PublicChatE2ETests.swift in Sources */,
+                                B7C18CECBE2D40D29E32CCBD /* PeerFingerprintMapperTests.swift in Sources */,
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
 		865C8403EF02C089369A9FCB /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -780,11 +807,12 @@
 				04636BD42E30BE5100FBCFA8 /* TestConstants.swift in Sources */,
 				04636BD52E30BE5100FBCFA8 /* MockBluetoothMeshService.swift in Sources */,
 				04636BD62E30BE5100FBCFA8 /* NoiseProtocolTests.swift in Sources */,
-				04636BD72E30BE5100FBCFA8 /* TestHelpers.swift in Sources */,
-				04636BD82E30BE5100FBCFA8 /* PublicChatE2ETests.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+                                04636BD72E30BE5100FBCFA8 /* TestHelpers.swift in Sources */,
+                                04636BD82E30BE5100FBCFA8 /* PublicChatE2ETests.swift in Sources */,
+                                DAA46FBB15014AF1A60AF7F5 /* PeerFingerprintMapperTests.swift in Sources */,
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */

--- a/bitchat-main/bitchat/Services/Identity/PeerFingerprintMapper.swift
+++ b/bitchat-main/bitchat/Services/Identity/PeerFingerprintMapper.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Thread-safe mapper from peer IDs to fingerprints with persistence.
+final class PeerFingerprintMapper {
+    static let shared = PeerFingerprintMapper()
+
+    private let defaults: UserDefaults
+    private let storageKey = "peerFingerprintMap:v1"
+    private let queue = DispatchQueue(label: "io.echo.identity.PeerFingerprintMapper", attributes: .concurrent)
+    private var map: [String: String]
+
+    init(defaults: UserDefaults = UserDefaults(suiteName: "io.echo.identity") ?? .standard) {
+        self.defaults = defaults
+        self.map = defaults.dictionary(forKey: storageKey) as? [String: String] ?? [:]
+    }
+
+    // MARK: - Public API
+
+    func fingerprint(forPeerID peerID: String) -> String? {
+        var result: String?
+        queue.sync { result = map[peerID] }
+        return result
+    }
+
+    func peerIDs(forFingerprint fingerprint: String) -> [String] {
+        var result: [String] = []
+        queue.sync {
+            result = map.compactMap { $0.value == fingerprint ? $0.key : nil }
+        }
+        return result
+    }
+
+    func setMapping(peerID: String, fingerprint: String) {
+        queue.sync(flags: .barrier) {
+            map[peerID] = fingerprint
+            persist()
+        }
+    }
+
+    func removePeerID(_ peerID: String) {
+        queue.sync(flags: .barrier) {
+            map.removeValue(forKey: peerID)
+            persist()
+        }
+    }
+
+    func removeAll(forFingerprint fingerprint: String) {
+        queue.sync(flags: .barrier) {
+            map = map.filter { $0.value != fingerprint }
+            persist()
+        }
+    }
+
+    // MARK: - Persistence
+
+    private func persist() {
+        defaults.set(map, forKey: storageKey)
+    }
+}
+

--- a/bitchat-main/bitchatTests/Identity/PeerFingerprintMapperTests.swift
+++ b/bitchat-main/bitchatTests/Identity/PeerFingerprintMapperTests.swift
@@ -19,23 +19,26 @@ final class PeerFingerprintMapperTests: XCTestCase {
 
     func testMappingAndPersistence() {
         var mapper = PeerFingerprintMapper(defaults: defaults)
-        mapper.setMapping(peerID: "peer1", fingerprint: "fp1")
+        mapper.setMapping(peerID: " Peer1 ", fingerprint: " FP1")
         mapper.setMapping(peerID: "peer2", fingerprint: "fp1")
         mapper.setMapping(peerID: "peer3", fingerprint: "fp2")
 
-        XCTAssertEqual(mapper.fingerprint(forPeerID: "peer1"), "fp1")
-        XCTAssertEqual(Set(mapper.peerIDs(forFingerprint: "fp1")), Set(["peer1", "peer2"]))
+        XCTAssertEqual(mapper.fingerprint(forPeerID: "PEER1"), "fp1")
+        XCTAssertEqual(Set(mapper.peerIDs(forFingerprint: " fp1 ")), Set(["peer1", "peer2"]))
 
-        mapper.removePeerID("peer1")
+        mapper.removePeerID("PEER1 ")
         XCTAssertNil(mapper.fingerprint(forPeerID: "peer1"))
-        XCTAssertEqual(mapper.peerIDs(forFingerprint: "fp1"), ["peer2"])
+        XCTAssertEqual(mapper.peerIDs(forFingerprint: "FP1"), ["peer2"])
 
-        mapper.removeAll(forFingerprint: "fp1")
+        mapper.removeAll(forFingerprint: " FP1 ")
         XCTAssertTrue(mapper.peerIDs(forFingerprint: "fp1").isEmpty)
         XCTAssertEqual(mapper.fingerprint(forPeerID: "peer3"), "fp2")
+
+        mapper.removeAll()
+        XCTAssertNil(mapper.fingerprint(forPeerID: "peer3"))
 
         mapper = PeerFingerprintMapper(defaults: defaults)
-        XCTAssertEqual(mapper.fingerprint(forPeerID: "peer3"), "fp2")
         XCTAssertTrue(mapper.peerIDs(forFingerprint: "fp1").isEmpty)
+        XCTAssertTrue(mapper.peerIDs(forFingerprint: "fp2").isEmpty)
     }
 }

--- a/bitchat-main/bitchatTests/Identity/PeerFingerprintMapperTests.swift
+++ b/bitchat-main/bitchatTests/Identity/PeerFingerprintMapperTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import bitchat
+
+final class PeerFingerprintMapperTests: XCTestCase {
+    private let suiteName = "io.echo.identity.tests"
+    private var defaults: UserDefaults! = nil
+
+    override func setUp() {
+        super.setUp()
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        super.tearDown()
+    }
+
+    func testMappingAndPersistence() {
+        var mapper = PeerFingerprintMapper(defaults: defaults)
+        mapper.setMapping(peerID: "peer1", fingerprint: "fp1")
+        mapper.setMapping(peerID: "peer2", fingerprint: "fp1")
+        mapper.setMapping(peerID: "peer3", fingerprint: "fp2")
+
+        XCTAssertEqual(mapper.fingerprint(forPeerID: "peer1"), "fp1")
+        XCTAssertEqual(Set(mapper.peerIDs(forFingerprint: "fp1")), Set(["peer1", "peer2"]))
+
+        mapper.removePeerID("peer1")
+        XCTAssertNil(mapper.fingerprint(forPeerID: "peer1"))
+        XCTAssertEqual(mapper.peerIDs(forFingerprint: "fp1"), ["peer2"])
+
+        mapper.removeAll(forFingerprint: "fp1")
+        XCTAssertTrue(mapper.peerIDs(forFingerprint: "fp1").isEmpty)
+        XCTAssertEqual(mapper.fingerprint(forPeerID: "peer3"), "fp2")
+
+        mapper = PeerFingerprintMapper(defaults: defaults)
+        XCTAssertEqual(mapper.fingerprint(forPeerID: "peer3"), "fp2")
+        XCTAssertTrue(mapper.peerIDs(forFingerprint: "fp1").isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- Add thread-safe `PeerFingerprintMapper` backed by `UserDefaults` for peer ID ↔︎ fingerprint lookups
- Add unit test covering mapping operations and persistence

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68989e3cad74832e847514df9b45b988