### PR TITLE
Add debug logging for PM consent flow

### DIFF
--- a/bitchat-main/bitchat/Services/BluetoothMeshService.swift
+++ b/bitchat-main/bitchat/Services/BluetoothMeshService.swift
@@ -4791,14 +4791,17 @@ class BluetoothMeshService: NSObject {
 
         case .pmRequest:
             let senderID = packet.senderID.hexEncodedString()
+            print("Service recv .pmRequest from \(senderID)")
             handlePMConsentMessage(.request, from: senderID, payload: packet.payload)
 
         case .pmAccept:
             let senderID = packet.senderID.hexEncodedString()
+            print("Service recv .pmAccept from \(senderID)")
             handlePMConsentMessage(.accept, from: senderID, payload: packet.payload)
 
         case .pmRefuse:
             let senderID = packet.senderID.hexEncodedString()
+            print("Service recv .pmRefuse from \(senderID)")
             handlePMConsentMessage(.refuse, from: senderID, payload: packet.payload)
 
         case .favorited:

--- a/bitchat-main/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat-main/bitchat/ViewModels/ChatViewModel.swift
@@ -3347,6 +3347,7 @@ class ChatViewModel: ObservableObject, BitchatDelegate {
     // MARK: - Consentement PM
 
     func didReceivePMConsent(_ msg: PMConsentMessage, from peerID: String, type: PMConsentAction) {
+        print("VM got \(type) from \(peerID)")
         DispatchQueue.main.async {
             switch type {
             case .request:

--- a/bitchat-main/bitchat/Views/ContentView.swift
+++ b/bitchat-main/bitchat/Views/ContentView.swift
@@ -209,6 +209,12 @@ struct ContentView: View {
         .sheet(isPresented: $showStaffSheet) {
             StaffCodeSheet()
         }
+        .onChange(of: viewModel.pendingPMConsent?.peerID) { newValue in
+            if let pid = newValue {
+                print("UI probe: pendingPMConsent set for peerID=\(pid)")
+            }
+            if showStaffSheet { showStaffSheet = false }
+        }
         .sheet(item: Binding(
             get: { viewModel.pendingPMConsent.map { PendingWrapper(value: $0) } },
             set: { _ in viewModel.pendingPMConsent = nil }
@@ -231,6 +237,9 @@ struct ContentView: View {
                     viewModel.meshService.sendPMConsent(.refuse, to: info.peerID)
                 }
             )
+            .onAppear {
+                print("UI probe: PMConsentSheet appeared for peerID=\(info.peerID)")
+            }
         }
         // ✅ Badge STAFF en overlay
         .overlay(alignment: .topTrailing) {


### PR DESCRIPTION
## Summary
- Log PM consent message types as they're received by BluetoothMeshService
- Trace PM consent delegate callbacks in ChatViewModel
- Add UI probes and sheet-closure guard for pending PM consent in ContentView

## Testing
- `swift test` *(fails: couldn't build due to multiple producers)*

------
https://chatgpt.com/codex/tasks/task_e_68993548edfc832e83390aeba5bb6c9c