### PR TITLE
Gracefully handle invalid PM consent payloads

### DIFF
--- a/bitchat-main/bitchat/Protocols/PMConsentMessage.swift
+++ b/bitchat-main/bitchat/Protocols/PMConsentMessage.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Represents a peer-to-peer consent message exchanged before private messaging
+struct PMConsentMessage: Codable {
+    /// Fingerprint associated with the consent request/response
+    let fingerprint: String
+
+    /// Create a consent message from raw binary data
+    /// - Parameter data: Encoded message payload
+    /// - Returns: A valid message or nil if decoding fails
+    static func fromBinaryData(_ data: Data) -> PMConsentMessage? {
+        do {
+            let decoded = try JSONDecoder().decode(PMConsentMessage.self, from: data)
+            return decoded
+        } catch {
+            print("PMConsentMessage: decode error: \(error)")
+            return nil
+        }
+    }
+}

--- a/bitchat-main/bitchat/Services/PMConsent/BluetoothMeshService+PMConsent.swift
+++ b/bitchat-main/bitchat/Services/PMConsent/BluetoothMeshService+PMConsent.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Extension handling PM consent-related messages
+extension BluetoothMeshService {
+    /// Handle an incoming PM consent message
+    /// - Parameters:
+    ///   - type: The consent message type
+    ///   - peerID: The sender peer identifier
+    ///   - payload: Raw message payload
+    func handlePMConsentMessage(type: PMConsentMessageType, from peerID: String, payload: Data) {
+        print("Service: handlePMConsentMessage \(type) from \(peerID) — bytes=\(payload.count)")
+
+        guard let msg = PMConsentMessage.fromBinaryData(payload) else {
+            print("Service: PMConsentMessage decode FAILED for \(type) from \(peerID)")
+            return
+        }
+
+        if msg.fingerprint.isEmpty {
+            print("Service: PMConsentMessage missing fingerprint for \(type) from \(peerID) — dropping")
+            return
+        }
+
+        print("Service: PMConsentMessage decode OK — fp=\(msg.fingerprint)")
+        print("Service: calling delegate.didReceivePMConsent \(type) for \(peerID)")
+        delegate?.didReceivePMConsent(msg, from: peerID, type: type)
+    }
+}
+
+/// PM consent message types supported by the mesh service
+enum PMConsentMessageType {
+    case request
+    case accept
+    case refuse
+}


### PR DESCRIPTION
## Summary
- Add safe parsing for `PMConsentMessage` payloads
- Guard fingerprint presence before invoking delegate

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68993d0f12a0832e8951c3b6f5707726